### PR TITLE
Replace PositiveInt with UInt

### DIFF
--- a/lib/Hashids.pm6
+++ b/lib/Hashids.pm6
@@ -5,7 +5,6 @@ unit class Hashids;
 # unique characters
 subset Alphabet of Str where !.comb.repeated and .chars >= 16;
 subset Salt of Str where .chars > 0;
-subset PositiveInt of Int where * >= 0;
 
 constant $RATIO-SEPARATORS = 3.5;
 constant $RATIO-GUARDS = 12;
@@ -143,7 +142,7 @@ method !ensure-length(Str $string, Str $alphabet, Int $values-hash) returns Str 
     return $encoded;
 }
 
-our sub hash(PositiveInt $n, Str $alphabet) returns Str {
+our sub hash(UInt $n, Str $alphabet) returns Str {
     my $number = $n;
     my $hashed = '';
     my $alphabet-len = $alphabet.chars;


### PR DESCRIPTION
Perl 6 already has [UInt](https://github.com/rakudo/rakudo/blob/c40374237bf986ef972a7e59aeb671eae72ac69f/src/core/Int.pm#L6) which is exactly the same as your definition of PositiveInt.  
I can only assume you saw one of the videos of Ovid's talk "Perl 6 for mere mortals"
