### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -2,6 +2,7 @@
   "authors" : [ "Bahtiar `kalkin-` Gadimov" ],
   "description" : "Hashids — generate short and reversable hashes from numbers.",
   "name" : "Hashids",
+  "license" : "MIT",
   "perl" : "6.c",
   "provides" : { "Hashids" : "lib/Hashids.pm6" },
   "source-url" : "https://github.com/kalkin/perl6-hashids.git",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license